### PR TITLE
Preserve call stack in cloned interpreter

### DIFF
--- a/Fuse.xs
+++ b/Fuse.xs
@@ -100,9 +100,9 @@ tTHX S_clone_interp(tTHX parent) {
 		PERL_SET_CONTEXT(parent);
 		dTHX;
 #if (PERL_VERSION > 10) || (PERL_VERSION == 10 && PERL_SUBVERSION >= 1)
-		tTHX child = perl_clone(parent, CLONEf_CLONE_HOST);
+		tTHX child = perl_clone(parent, CLONEf_CLONE_HOST | CLONEf_COPY_STACKS);
 #else
-		tTHX child = perl_clone(parent, CLONEf_CLONE_HOST | CLONEf_KEEP_PTR_TABLE);
+		tTHX child = perl_clone(parent, CLONEf_CLONE_HOST | CLONEf_COPY_STACKS | CLONEf_KEEP_PTR_TABLE);
 		ptr_table_free(PL_ptr_table);
 		PL_ptr_table = NULL;
 #endif


### PR DESCRIPTION
In perl 5.14 threaded mode doesn't work in Fuse. It appears the issue is caused after the interpreter has been cloned when call_sv is triggered.  A quick fix is to add the CLONEf_COPY_STACKS flag to the perl_clone call.

Because of that I'm guessing it something with how an empty stack is treated in a new interpreter in perl 5.14. There were several fixes with addressing memory leaks of lexicals when creating a new interpreter. I would guess the call_sv is referencing a function that has now been freed in the latest version of perl, but keeping the existing call stack prevents the function from being freed.

I'm not completely sure the ramifications of keeping the stack in all cloned interpreters would be at cleanup time, but we already currently ignore clean-up of created interpreters once the mount point is unmounted. At some point work needs to be done to clean up our threads and variables when unmounting, at that point CLONEf_COPY_STACKS will probably need to be re-evaluated.
