### PR TITLE
set the fragment size to the same value as the block size

### DIFF
--- a/Fuse.xs
+++ b/Fuse.xs
@@ -681,8 +681,8 @@ int _PLfuse_statfs (const char *file, struct statvfs *st) {
 		st->f_namemax	= POPi;
 		/* zero and fill-in other */
 		st->f_fsid = 0;
-		st->f_frsize = 4096;
 		st->f_flag = 0;
+		st->f_frsize = st->f_bsize;
 		st->f_bavail = st->f_bfree;
 		st->f_favail = st->f_ffree;
 


### PR DESCRIPTION
I ran into an issue where a Fuse mount was correctly reporting the free space in df on FC17, but the same share when viewed from OSX 10.8 over samba was reporting incorrect free space. It appears that some free space calculations use frsize and some use bsize, so for now we should set them to the same value.

see: http://article.gmane.org/gmane.comp.file-systems.fuse.devel/3902
