### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,26 +1,85 @@
-Revision history for Perl extension Fuse.
+Revision history for Perl module Fuse
 
-0.01  Wed Nov 28 21:45:20 2001
-	- original version; created by h2xs 1.21 with options
-		include/fuse.h
+0.16 2013-09-15
+	- Fix unbounded stack growth due to previous changes in getdir()
+	  and readdir() wrappers that didn't properly decrement SP.
+	  [RT #77321]
+	- Implement support for FUSE 2.9 specific operations. (flock,
+	  read_buf, write_buf, fallocate)
+	- Implement helper functions (fuse_buf_size, fuse_buf_copy) for
+	  handling generic buffers inside read_buf and write_buf
+	  wrappers.
+	- Make the write() wrapper do less data copying.
+	- Improve compatibility with OpenIndiana (an open flavor of
+	  Solaris).
+	- Add support for OpenBSD's flavor of FUSE.
 
-0.02 Sun Dec 2 18:59:56 2001
-    - works well enough to release, but still needs testing
+0.15 2013-06-08
+	- Eliminate more uses of system() in tests.
+	- Enable the ioctl() operation when built against FUSE 2.8 or later.
+	  Also wrote tests based off fioc.c and fioclient.c from FUSE.
+	- Use smaller getattr test sizes only on MacOS X.
+	- Permanently fix the XATTR_{CREATE,REPLACE} symbols.
+	- Add a wrapper for the poll() operation when built against FUSE 2.8
+	  or later. Also wrote tests based off fsel.c and fselclient.c
+	  from FUSE.
+	- Fixed a thinko in the platform handling chain in Makefile.PL.
+	- Added handling for sub-second [amc]time stamps.
+	- Improve compatibility with Fuse4X.
+	- Improve future compatibility with non-Linux FUSE 2.8
+	  implementations.
 
-0.03 Wed Dec 5 02:17:52 2001
-    - changed getattr() to smell like perl's stat()
-	- fleshed out the documentation a bit
+0.14 2011-08-01
+	- Retooling portions of the test facilities, and removing dependence
+	  on syscall() and knowing syscall numbers for basic test
+	  functionality.
+	- Compatibility fixes for Perl 5.8 and Perl 5.13/5.14 with threads.
+	- Cleanups to build system, to use pkg-config to get the Fuse
+	  build arguments for building our code against the installed
+	  libfuse. Cleans up some of the mess before of different ways of
+	  handling different OSes; NetBSD is still a bit messy due to
+	  librefuse.
+	- Decrease file sizes in getattr test, to keep test from running
+	  for multiple hours (due to HFS+ not supporting sparse files).
 
-0.04 Thu Nov 18 13:51:56 CET 2004
-    - new maintainer, Dobrica Pavlinusic <dpavlin@rot13.org>
-    - updated to work with current CVS version of fuse
+0.13 2011-07-03
+	- improved support for FreeBSD, NetBSD and OS X
+	- restored non-threaded perl support
 
-0.06 Sun Apr 03 16:15:00 BST 2005
-    - Add support for operations supported by FUSE 2.2.1
-      (flush, release, fsync, extended attributes)
-    - add mount options
+0.12 2011-05-20
+	- all changes in this version are contributed by Darrik Pates
+	- BACKWARD COMPATILIBY CHANGE: readdir introduced in 0.11 changed!
+	- mount option -o big_writes, and added:
+	  opendir, releasedir, fsyncdir, init, destroy, access, create,
+	  ftruncate, fgetattr, lock, utimens, bmap
 
-0.07 Sun Dec 25 10:37:00 PST 2005
+0.11 2011-02-25
+	- make static callbacks thread-safe, contributed by Daniel Frett
+	- readdir implmenentation contributed by Alex Sudakov RT #55953
+
+0.10_1 2011-01-17
+	- cleanup options
+	- 64 bit perl support submitted by Derrik Pates
+
+0.09_4 2010-05-16
+	- Justin Fletcher addition of file handles on open files, RT #57517
+
+0.09_3 2008-03-19
+    - really fix 2+ Gb file bug, RT #32639, RT #33903
+
+0.09 2007-11-15
+    - support dh-make-perl with fakeroot
+    - added fuse_get_context
+    - works with MacFUSE http://code.google.com/p/macfuse/
+    - added example filter_attr_fs.pl
+
+0.08 2006-11-29 14:24:39 CET
+    - fix race condition in test/s/mount.t
+    - allow Fuse to be run from a non-master thread
+    - CPANPLUS doesn't report errors anymore if fuse isn't installed
+    - fix to test helper
+
+0.07 2005-12-25 10:37:00 PST
     - Remove the FUSE_DEBUG constant; we never actually implemented
       it to begin with.
     - "make test" now uses the version of Fuse you've just built,
@@ -41,81 +100,23 @@ Revision history for Perl extension Fuse.
     - Update docs accordingly.  Update examples accordingly.
     - Works on FreeBSD with fuse4bsd http://fuse4bsd.creo.hu/
 
-0.08 Wed Nov 29 14:24:39 CET 2006
-    - fix race condition in test/s/mount.t
-    - allow Fuse to be run from a non-master thread
-    - CPANPLUS doesn't report errors anymore if fuse isn't installed
-    - fix to test helper
+0.06 2005-04-03 16:15:00 BST
+    - Add support for operations supported by FUSE 2.2.1
+      (flush, release, fsync, extended attributes)
+    - add mount options
 
-0.09
-    - support dh-make-perl with fakeroot
-    - added fuse_get_context
-    - works with MacFUSE http://code.google.com/p/macfuse/
-    - added example filter_attr_fs.pl
+0.04 2004-11-18 13:51:56 CET
+    - new maintainer, Dobrica Pavlinusic <dpavlin@rot13.org>
+    - updated to work with current CVS version of fuse
 
-0.09_3
-    - really fix 2+ Gb file bug, RT #32639, RT #33903
+0.03 2001-12-05 02:17:52
+    - changed getattr() to smell like perl's stat()
+	- fleshed out the documentation a bit
 
-0.09_4
-	- Justin Fletcher addition of file handles on open files, RT #57517
+0.02 2001-12-02 18:59:56
+    - works well enough to release, but still needs testing
 
-0.10_1
-	- cleanup options
-	- 64 bit perl support submitted by Derrik Pates
+0.01 2001-11-28 21:45:20
+	- original version; created by h2xs 1.21 with options
+		include/fuse.h
 
-0.11
-	- make static callbacks thread-safe, contributed by Daniel Frett
-	- readdir implmenentation contributed by Alex Sudakov RT #55953
-
-0.12
-	- all changes in this version are contributed by Darrik Pates
-	- BACKWARD COMPATILIBY CHANGE: readdir introduced in 0.11 changed!
-	- mount option -o big_writes, and added:
-	  opendir, releasedir, fsyncdir, init, destroy, access, create,
-	  ftruncate, fgetattr, lock, utimens, bmap
-
-0.13
-	- improved support for FreeBSD, NetBSD and OS X
-	- restored non-threaded perl support
-
-0.14
-	- Retooling portions of the test facilities, and removing dependence
-	  on syscall() and knowing syscall numbers for basic test
-	  functionality.
-	- Compatibility fixes for Perl 5.8 and Perl 5.13/5.14 with threads.
-	- Cleanups to build system, to use pkg-config to get the Fuse
-	  build arguments for building our code against the installed
-	  libfuse. Cleans up some of the mess before of different ways of
-	  handling different OSes; NetBSD is still a bit messy due to
-	  librefuse.
-	- Decrease file sizes in getattr test, to keep test from running
-	  for multiple hours (due to HFS+ not supporting sparse files).
-
-0.15
-	- Eliminate more uses of system() in tests.
-	- Enable the ioctl() operation when built against FUSE 2.8 or later.
-	  Also wrote tests based off fioc.c and fioclient.c from FUSE.
-	- Use smaller getattr test sizes only on MacOS X.
-	- Permanently fix the XATTR_{CREATE,REPLACE} symbols.
-	- Add a wrapper for the poll() operation when built against FUSE 2.8
-	  or later. Also wrote tests based off fsel.c and fselclient.c
-	  from FUSE.
-	- Fixed a thinko in the platform handling chain in Makefile.PL.
-	- Added handling for sub-second [amc]time stamps.
-	- Improve compatibility with Fuse4X.
-	- Improve future compatibility with non-Linux FUSE 2.8
-	  implementations.
-
-0.16
-	- Fix unbounded stack growth due to previous changes in getdir()
-	  and readdir() wrappers that didn't properly decrement SP.
-	  [RT #77321]
-	- Implement support for FUSE 2.9 specific operations. (flock,
-	  read_buf, write_buf, fallocate)
-	- Implement helper functions (fuse_buf_size, fuse_buf_copy) for
-	  handling generic buffers inside read_buf and write_buf
-	  wrappers.
-	- Make the write() wrapper do less data copying.
-	- Improve compatibility with OpenIndiana (an open flavor of
-	  Solaris).
-	- Add support for OpenBSD's flavor of FUSE.


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec - this involved:
- Reversed the order so most recent release is listed first
- Not all the releases had dates against them, so I looked them up on BackPAN
- Put all dates in ISO 8601 format

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
