### PR TITLE
allow multiple threads calling fuse_main simultaneously

### DIFF
--- a/Fuse.xs
+++ b/Fuse.xs
@@ -2184,7 +2184,7 @@ perl_fuse_main(...)
 	struct fuse_args args = FUSE_ARGS_INIT(0, NULL);
 	struct fuse_chan *fc;
 	fuse_private_data_t *private_data;
-	Newx(private_data, 1, fuse_private_data_t);
+	Newx(private_data, sizeof *private_data, fuse_private_data_t);
 #ifdef FUSE_USE_ITHREADS
 	private_data->self = aTHX;
 #endif


### PR DESCRIPTION
Currently, we don't support multiple threads each setting up a fuse file system if at least one of them also wants threaded callbacks. This test program:

<pre>#!/usr/bin/perl
use threads;
use threads::shared;
use Fuse;
use POSIX qw(EIO);

mkdir("a");
mkdir("b");
async { Fuse::main(mountpoint=>"a", threaded=>1, getattr => sub { warn "a"; sleep(1); return -EIO()}) };
async { Fuse::main(mountpoint=>"b", threaded=>1, getattr => sub { warn "b"; sleep(1); return -EIO()}) };
sleep(10);
system("ls a/");
system("ls b/");
</pre>


will print "b" twice, and never print "a" (it's fine with threaded=>0 in both calls). The problem is the global master_interp variable, which we use to fake a thread context in CLONE_INTERP(). This very lightly-tested patch fixes that by putting the master interpreter into the fuse context's private data; I still have to convince myself the right thing happens when we create a thread from within a FUSE callback (which might call fuse_main itself, ugh...), but 

Anyway, would such a patch be acceptable?

As an aside, it seems that the return value of PLfuse_init is now ignored, so I didn't bother "fixing" that function yet.
