### PR TITLE
tries to use PkgConfig whenever 'pkg-config' is not available

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use ExtUtils::MakeMaker;
+use File::Spec;
 use POSIX;
 use Config;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
@@ -27,7 +28,58 @@ sub test_via_script {
 
 package main;
 
-chomp(my $fusever = `pkg-config --modversion fuse 2> /dev/null`);
+# 'can_run' courtesy of Module::Install
+sub can_run {
+    my ($cmd) = @_;
+
+    my $_cmd = $cmd;
+    return $_cmd if (-x $_cmd or $_cmd = MM->maybe_command($_cmd));
+
+    for my $dir ((split /$Config::Config{path_sep}/, $ENV{PATH}), '.') {
+        next if $dir eq '';
+        my $abs = File::Spec->catfile($dir, $cmd);
+        return $abs if (-x $abs or $abs = MM->maybe_command($abs));
+    }
+    return;
+}
+
+# Fix Cygwin bug on maybe_command() - also courtesy of Module::Install;
+if ( $^O eq 'cygwin' ) {
+    require ExtUtils::MM_Cygwin;
+    require ExtUtils::MM_Win32;
+    if ( ! defined(&ExtUtils::MM_Cygwin::maybe_command) ) {
+        *ExtUtils::MM_Cygwin::maybe_command = sub {
+            my ($self, $file) = @_;
+            if ($file =~ m{^/cygdrive/}i and ExtUtils::MM_Win32->can('maybe_command')) {
+                    ExtUtils::MM_Win32->maybe_command($file);
+            } else {
+                    ExtUtils::MM_Unix->maybe_command($file);
+            }
+        }
+    }
+}
+
+my $command;
+if ( can_run('pkg-config') ) {
+    $command = 'pkg-config';
+}
+elsif ( can_run('ppkg-config') ) {
+    # we use flags that are only available after 0.08626
+    my $pkg_version = `ppkg-config --real-version`;
+    if ($pkg_version =~ /Version: (\d+\.\d+)/) {
+        if ($1 >= 0.08626) {
+            $command = 'ppkg-config';
+        }
+        else {
+            die "Outdated PkgConfig ($1). Please upgrade to 0.08626 or later.\n";
+        }
+    }
+}
+else {
+    die "Cannot build. Please install pkg-config or the PkgConfig perl module before continuing.\n";
+}
+
+chomp(my $fusever = `$command --modversion fuse 2> /dev/null`);
 # Required for refuse on NetBSD
 if (!$fusever && $^O eq 'netbsd') {
     chomp($fusever = `fusermount -V`);
@@ -55,7 +107,7 @@ unless ($fusever) {
         $explanation = 'Could not find librefuse? Maybe install "perfuse" from pkgsrc, or upgrade to newer NetBSD';
     }
     elsif ($^O eq 'darwin') {
-        $explanation = 'Please install OSXFUSE from http://osxfuse.github.com/';
+        $explanation = 'Please install OSXFUSE from http://osxfuse.github.com/ or via homebrew (brew install osxfuse)';
     }
     elsif ($^O eq 'solaris') {
         open(my $motd, '<', '/etc/motd');
@@ -81,9 +133,9 @@ if ($fusever && $fusever + 0 < 2.6) {
     warn "fuse version found: ", $fusever, "\n";
 }
 
-chomp(my $inc = `pkg-config --cflags-only-I fuse 2> /dev/null`);
-chomp(my $libs = `pkg-config --libs-only-L fuse 2> /dev/null`);
-chomp($libs .= `pkg-config --libs-only-l fuse 2> /dev/null` || (($^O eq 'netbsd') ? '-lrefuse' : '-lfuse'));
+chomp(my $inc = `$command --cflags-only-I fuse 2> /dev/null`);
+chomp(my $libs = `$command --libs-only-L fuse 2> /dev/null`);
+chomp($libs .= `$command --libs-only-l fuse 2> /dev/null` || (($^O eq 'netbsd') ? '-lrefuse' : '-lfuse'));
 # Needed for Fuse on OS X 10.6, due to 10.6 and up always using the 64-bit
 # inode structs; unfortunately MacFuse doesn't just do the right thing
 # on its own. (Not applicable for OSXFUSE; it uses a new SONAME, so we
@@ -91,8 +143,8 @@ chomp($libs .= `pkg-config --libs-only-l fuse 2> /dev/null` || (($^O eq 'netbsd'
 if ($^O eq 'darwin' && (uname())[2] =~ /^1[01]\./) {
     $libs =~ s/-lfuse\b/-lfuse_ino64/;
 }
-chomp(my $def = '-Wall -DFUSE_USE_VERSION=26 ' . `pkg-config --cflags-only-other fuse 2> /dev/null` || '-D_FILE_OFFSET_BITS=64');
-chomp($def .= `pkg-config --libs-only-other fuse 2> /dev/null`);
+chomp(my $def = '-Wall -DFUSE_USE_VERSION=26 ' . `$command --cflags-only-other fuse 2> /dev/null` || '-D_FILE_OFFSET_BITS=64');
+chomp($def .= `$command --libs-only-other fuse 2> /dev/null`);
 $def .= ' -DPERL_HAS_64BITINT' if $Config{'use64bitint'};
 $def .= ' -DUSING_LIBREFUSE' if $libs =~ m{-lrefuse\b};
 

--- a/test/helper.pm
+++ b/test/helper.pm
@@ -7,12 +7,20 @@ use Config;
 use POSIX qw(WEXITSTATUS);
 our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 @ISA = "Exporter";
-@EXPORT_OK = qw($_loop $_opts $_point $_pidfile $_real);
+@EXPORT_OK = qw($_loop $_opts $_point $_pidfile $_real $_logfile);
 my $tmp = -d '/private' ? '/private/tmp' : '/tmp';
-our($_loop, $_point, $_pidfile, $_real, $_opts) = ('examples/loopback.pl',"$tmp/fusemnt-".$ENV{LOGNAME},$ENV{'PWD'} . "/test/s/mounted.pid","$tmp/fusetest-".$ENV{LOGNAME}, '');
-$_opts = ' --pidfile ' . $_pidfile;
-$_opts .= ' --logfile /tmp/fusemnt.log';
+
+our $_loop    = 'examples/loopback.pl';
+our $_point   = "$tmp/fusemnt-".$ENV{LOGNAME};
+our $_pidfile = $ENV{'PWD'} . "/test/s/mounted.pid";
+our $_real    = "$tmp/fusetest-".$ENV{LOGNAME};
+our $_opts    = '';
+our $_logfile = "$tmp/fusemnt.log";
+
+$_opts  = ' --pidfile ' . $_pidfile;
+$_opts .= ' --logfile ' . $_logfile;
 $_opts .= $Config{useithreads} ? ' --use-threads' : '';
+
 if($0 !~ qr|s/u?mount\.t$|) {
 	my ($reject) = 1;
 	if(open my $fh, '<', $_pidfile) {

--- a/test/s/mount.t
+++ b/test/s/mount.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-use test::helper qw($_point $_loop $_opts $_real $_pidfile);
+use test::helper qw($_point $_loop $_opts $_real $_pidfile $_logfile);
 use strict;
 use Errno qw(:POSIX);
 use Test::More tests => 3;
@@ -10,12 +10,12 @@ sub is_mounted {
 	return $diag =~ $pattern;
 }
 
-ok(!is_mounted(),"already mounted");
+ok(!is_mounted(),"not already mounted");
 ok(-f $_loop,"loopback exists");
 
 mkdir $_point;
 mkdir $_real;
-diag "mounting $_loop to $_point";
+diag "mounting $_loop to $_point with $_opts";
 open REALSTDOUT, '>&STDOUT';
 open REALSTDERR, '>&STDERR';
 open STDOUT, '>', '/dev/null';
@@ -29,13 +29,22 @@ while ($count++ < 50 && !$success) {
 	select(undef, undef, undef, 0.1);
 	($success) = is_mounted();
 }
-diag "Mounted in ", $count/10, " secs";
 
-ok($success,"mount succeeded");
+ok( $success, "mount succeeded" );
 system("rm -rf $_real");
-unless($success) {
-	kill('INT',`cat $_pidfile`);
-	unlink($_pidfile);
-} else {
+
+if ($success) {
+    diag "mounted in " . $count/10 . " secs";
 	mkdir($_real);
+}
+else {
+    if (-e $_logfile) {
+        my $error = `cat $_logfile`;
+        diag "error mounting $_loop:\n$errors";
+        unlink $_logfile;
+    }
+    if (-e $_pidfile) {
+        kill('INT',`cat $_pidfile`);
+        unlink($_pidfile);
+    }
 }


### PR DESCRIPTION
Hello! First off, thank you for this Fuse binding for Perl.

While I am still unable to run it properly under OS X (see [related issue](https://rt.cpan.org/Ticket/Display.html?id=101739)), I managed to go as far as compiling it. Turns out OS X doesn't come with `pkg-config`: users have to either install it or use some sort of equivalent.

Fortunately, there is a pure-perl version with no non-core dependencies called [PkgConfig](https://metacpan.org/pod/PkgConfig), which provides the `ppkg-config` 1:1 equivalent.

This patch tries to use it when it can't find `pkg-config` on the system.

This patch also tries a little harder to find both `pkg-config` and `ppkg-config` using a trick from Module::Install, and the main test file was slightly tweaked to also allow exporting of the logfile and thus better diagnostics in case something went wrong (which is how I was able to create the ticket.

I hope this helps! Thanks!