### PR TITLE
bumping up next version to 0.17 (fixes RT#92865)

### DIFF
--- a/Fuse.pm
+++ b/Fuse.pm
@@ -31,7 +31,7 @@ our %EXPORT_TAGS = (
 our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 
 our @EXPORT = ();
-our $VERSION = '0.16_1';
+our $VERSION = '0.17';
 
 sub AUTOLOAD {
     # This AUTOLOAD is used to 'autoload' constants from the constant()


### PR DESCRIPTION
Hi again :)

Perl Fuse has historically used single-dotted version numbers (0.1, 0.2, ..., 0.15, 0.16) for its distributions, but the latest version changed to double-dotted semantic versioning (0.16.1). This change confused CPAN as it translates 0.16.1 to 0.016001, which is lower than 0.160000 (0.16), and because of that 0.16 is still marked as latest.

This is a simple pull request that bumps $VERSION to 0.17, assuming you want to keep single-dotted versions. This will fix https://rt.cpan.org/Public/Bug/Display.html?id=92865 and allow people to seamlessly install the latest version of Fuse through CPAN.

Hope it helps!